### PR TITLE
Zend framework use empty string instead of null

### DIFF
--- a/src/Codeception/Lib/Connector/ZF2.php
+++ b/src/Codeception/Lib/Connector/ZF2.php
@@ -74,7 +74,7 @@ class ZF2 extends Client
         $zendRequest->setQuery(new Parameters($query));
         $zendRequest->setPost(new Parameters($post));
         $zendRequest->setFiles(new Parameters($request->getFiles()));
-        $zendRequest->setContent($content);
+        $zendRequest->setContent(is_null($content) ? '' : $content);
         $zendRequest->setMethod($method);
         $zendRequest->setUri($uri);
         $requestUri = $uri->getPath();


### PR DESCRIPTION
In some cases for example when converting zend to psr7 request `null` content causes error: `fwrite() expects parameter 2 to be string, null given` it seems zend uses `''` instead of null for this and an empty string is the default value for Zend request