### PR TITLE
add persisted services before bootstrap

### DIFF
--- a/src/Codeception/Lib/Connector/ZF2.php
+++ b/src/Codeception/Lib/Connector/ZF2.php
@@ -193,6 +193,7 @@ class ZF2 extends Client
         $serviceManager->get('ModuleManager')->loadModules();
 
         // Keep persisted services persisted
+        $serviceManager->setAllowOverride(true);
         foreach ($this->persistentServices as $serviceName => $service) {
             $serviceManager->setService($serviceName, $service);
         }

--- a/src/Codeception/Lib/Connector/ZF2.php
+++ b/src/Codeception/Lib/Connector/ZF2.php
@@ -176,6 +176,9 @@ class ZF2 extends Client
         }
     }
 
+    /**
+     * This is modified Zend\Application::init() to support persisted services
+     */
     private function bootstrapApplication($configuration = [])
     {
         // Prepare the service manager


### PR DESCRIPTION
when using doctrine I noticed that if you do something in bootstrap you won't get persisted doctrine entity manager but instead new will be created so had to change when persisted entities we set. Now when all modules are loaded we can add persisted services for example doctrine in this case and just then bootstrap MVC application